### PR TITLE
Handle converting empty mochijson2 objects properly.

### DIFF
--- a/src/props.erl
+++ b/src/props.erl
@@ -428,6 +428,8 @@ to_proplist(Value) ->
 
 %% @doc converts from mochijson2 format (http://doc.erlagner.org/mochiweb/mochijson2.html) to props
 -spec from_mochijson2(term()) -> props:props().
+from_mochijson2({struct, PropList}) when is_list(PropList), length(PropList) =:= 0 ->
+    props:new();
 from_mochijson2({struct, PropList}) when is_list(PropList) ->
     props:set(from_mochijson2(PropList));
 from_mochijson2(List) when is_list(List) ->


### PR DESCRIPTION
Return new props objects when decoding empty structures instead of crashing. Handles empty objects in deep structures properly as well.

Before:
props:from_mochijson2({struct, []}).
*\* exception error: no function clause matching props:do_set({fail,{expected,{character_class,"[_a-zA-Z0-9]"},
                                                                             {{line,1},{column,1}}}},
                                                             {[]},
                                                             {[]}) (src/props.erl, line 137)
After:
props:from_mochijson2({struct, []}).
{[]}
