### PR TITLE
Peg project dependencies to specific versions.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,6 +12,6 @@
              {stylesheet, ""}]}.
 
 {deps, [{edown, ".*",
-         {git, "git://github.com/esl/edown.git", "master"}},
+         {git, "git://github.com/esl/edown.git", "35f8296a25"}},
         {neotoma, "1.5",
-         {git, "git://github.com/seancribbs/neotoma.git", "master"}}]}.
+         {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.5-stable"}}}]}.


### PR DESCRIPTION
Three days ago props began to fail in building when neotoma updated its master
branch to be 1.6, rather than 1.5. This commit ensures that all future builds
peg dependencies at known-to-build versions.

(An alternative would be to continue to target master and remove the 1.5
assertion, but I'm fond of building against a known target.)

Signed-off-by: Brian L. Troutwine brian.troutwine@rackspace.com
