### PR TITLE
Added support for lists of proplists

### DIFF
--- a/test/props_SUITE.erl
+++ b/test/props_SUITE.erl
@@ -28,7 +28,8 @@
          delete_matches/1,
          delete_matches_nested/1,
          convert_mochijson2_to_props/1,
-         set_with_empty_list/1]).
+         set_with_empty_list/1,
+         list_of_proplists/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -81,7 +82,8 @@ all() ->
      delete_matches,
      delete_matches_nested,
      convert_mochijson2_to_props,
-     set_with_empty_list].
+     set_with_empty_list,
+     list_of_proplists].
 
 %% Basic get tests.
 
@@ -247,3 +249,19 @@ set_with_empty_list(_Config) ->
     N = props:set([], props:new()),
     ok.
 
+list_of_proplists(_Config) ->
+    Expected = {[
+        {<<"hello">>, world}, 
+        {<<"foo">>, [
+            {[{<<"bar">>, 1}]},
+            {[{<<"baz">>, 2}]}
+        ]}
+    ]},
+    Result = props:from_proplist([
+        {hello, world},
+        {foo, [
+            [{bar, 1}],
+            [{baz, 2}]
+        ]}
+    ]),
+    Expected = Result.


### PR DESCRIPTION
Added support for lists of proplists in from_proplist/1.

Right now when attempt to convert a `list()` of `propslists:proplist()` (in a proplist) to a `props()` (analogous to an array of objects in JSON), it is not converted fully. For example:
```
Erlang R15B02 (erts-5.9.2) [source] [64-bit] [smp:4:4] [async-threads:0] [hipe] [kernel-poll:false]

Eshell V5.9.2  (abort with ^G)
1> Expected = {[
1>   {<<"hello">>, world},
1>   {<<"foo">>, [
1>       {[{<<"bar">>, 1}]},
1>       {[{<<"baz">>, 2}]}
1>   ]}
1> ]},
1> Result = props:from_proplist([
1>   {hello, world},
1>   {foo, [
1>       [{bar, 1}],
1>       [{baz, 2}]
1>   ]}
1> ]),
1> Expected = Result.
** exception error: no match of right hand side value {[{<<"hello">>,world},{<<"foo">>,[[{bar,1}],[{baz,2}]]}]}
2> 
```