### PR TITLE
Allow {Key, proplists:proplist()} entries to be converted

### DIFF
--- a/src/props.erl
+++ b/src/props.erl
@@ -244,6 +244,8 @@ from_proplist(PropList) ->
   PropList2 = lists:map(fun convert_proplist_entry/1, PropList),
   {PropList2}.
 
+convert_proplist_entry({Key, [{_, _} | _] = Proplist}) ->
+  convert_proplist_entry({Key, from_proplist(Proplist)});
 convert_proplist_entry({Key, [[{_, _} | _] | _] = ListOfProplists}) ->
   NestedProplists = lists:map(fun from_proplist/1, ListOfProplists),
   convert_proplist_entry({Key, NestedProplists});

--- a/test/props_SUITE.erl
+++ b/test/props_SUITE.erl
@@ -29,7 +29,8 @@
          delete_matches_nested/1,
          convert_mochijson2_to_props/1,
          set_with_empty_list/1,
-         list_of_proplists/1]).
+         list_of_proplists/1,
+         nested_proplist/1]).
 
 -include_lib("common_test/include/ct.hrl").
 
@@ -83,7 +84,8 @@ all() ->
      delete_matches_nested,
      convert_mochijson2_to_props,
      set_with_empty_list,
-     list_of_proplists].
+     list_of_proplists,
+     nested_proplist].
 
 %% Basic get tests.
 
@@ -262,6 +264,21 @@ list_of_proplists(_Config) ->
         {foo, [
             [{bar, 1}],
             [{baz, 2}]
+        ]}
+    ]),
+    Expected = Result.
+
+nested_proplist(_Config) ->
+    Expected = {[
+        {<<"foo">>, {[
+            {<<"bar">>, 1},
+            {<<"baz">>, 2}
+        ]}}
+    ]},
+    Result = props:from_proplist([
+        {foo, [
+            {bar, 1},
+            {baz, 2}
         ]}
     ]),
     Expected = Result.


### PR DESCRIPTION
Changed embedded proplists (not just lists of proplists) to be passed through `from_proplist/1` as well.

Currently `from_proplist/1` doesn't handle nested values that might also happen to be proplists. Similar in nature to "lists of proplists", the goal is to make the following 3 things equivalent (basically):

``` erlang
% proplists:proplist()
[
  {foo, [
    {bar, 1},
    {baz, 2}
  ]}
]).
```

``` erlang
% props:props()
{[
  {<<"foo">>, {[
    {<<"bar">>, 1},
    {<<"baz">>, 2}
  ]}}
]}.
```

``` json
{
  "foo": {
    "bar": 1,
    "baz": 2
  }
}
```
